### PR TITLE
Limit coordinate to 0.0.18 or 0.0.19

### DIFF
--- a/geodetic.cabal
+++ b/geodetic.cabal
@@ -31,7 +31,7 @@ library
   build-depends:
                     base < 5 && >= 3
                     , lens >= 4.0
-                    , coordinate >= 0.0.18
+                    , coordinate >= 0.0.18 && < 0.0.20
                     , radian >= 0.0.4
                     , optional >= 0.0.1
 


### PR DESCRIPTION
This doesn't fix #1, but it prevents accidentally installing the wrong
version of coordinate, leading to build failure of geodetic